### PR TITLE
Add Entry respond_to? that corresponds to method_missing

### DIFF
--- a/lib/mongoid/audit_log/entry.rb
+++ b/lib/mongoid/audit_log/entry.rb
@@ -50,6 +50,11 @@ module Mongoid
         @modifier = modifier
       end
 
+      def respond_to?(sym, *args)
+        key = sym.to_s
+        (caches.present? && caches.has_key?(key)) || super
+      end
+
       def method_missing(sym, *args, &block)
         key = sym.to_s
 

--- a/spec/mongoid/audit_log/entry_spec.rb
+++ b/spec/mongoid/audit_log/entry_spec.rb
@@ -71,6 +71,15 @@ module Mongoid
         end
       end
 
+      describe '#respond_to?' do
+        let(:entry) { Entry.new(:caches => { 'name' => 'foo', 'other' => nil }) }
+
+        it 'returns true for cached methods it responds to' do
+          entry.respond_to?(:name).should be_true
+          entry.respond_to?(:other).should be_true
+        end
+      end
+
       describe '#method_missing' do
         let(:entry) { Entry.new(:caches => { 'name' => 'foo', 'other' => nil }) }
 


### PR DESCRIPTION
This pull request adds an implementation for respond_to? for Mongoid::AuditLog::Entry that corresponds to the implementation of method_missing.
