### PR TITLE
Ensuring that thread variables are unset on failure

### DIFF
--- a/lib/mongoid/audit_log.rb
+++ b/lib/mongoid/audit_log.rb
@@ -27,6 +27,7 @@ module Mongoid
       Thread.current[:mongoid_audit_log_recording] = true
       Thread.current[:mongoid_audit_log_modifier] = modifier
       yield
+    ensure
       Thread.current[:mongoid_audit_log_recording] = nil
       Thread.current[:mongoid_audit_log_modifier] = nil
     end
@@ -35,6 +36,7 @@ module Mongoid
       tmp = Thread.current[:mongoid_audit_log_recording]
       Thread.current[:mongoid_audit_log_recording] = false
       yield
+    ensure
       Thread.current[:mongoid_audit_log_recording] = tmp
     end
 

--- a/spec/mongoid/audit_log_spec.rb
+++ b/spec/mongoid/audit_log_spec.rb
@@ -71,6 +71,27 @@ module Mongoid
           product.audit_log_entries.first.modifier.should == user
         end
       end
+
+      it 'properly unsets recording on failure' do
+        expect do
+          AuditLog.record do
+            raise
+          end
+        end.to raise_error(Exception)
+
+        AuditLog.recording?.should == false
+      end
+
+      it 'properly unsets modifier on failure' do
+        user = User.create!
+        expect do
+          AuditLog.record(user) do
+            raise
+          end
+        end.to raise_error(Exception)
+
+        AuditLog.current_modifier.should == nil
+      end
     end
 
     describe '.disable' do


### PR DESCRIPTION
Noticed that if an exception is thrown for whatever reason we aren't ensuring that the thread variables are unset which could lead to attributing audit log entries to the wrong user.