### PR TITLE
Allow models to disable logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,29 @@ model == Model.find_by(name: 'foo bar') # => true
 
 It's possible to end up in a situation where a destroy entry cannot be restored, e.g. an entry deleting an embedded document for a root document that's already been deleted. In these scenarios, `Mongoid::AuditLog::Restore::InvalidRestore` will be raised.
 
+### Disabling
+
+The `AuditLog` module provides methods to included classes to allow explicit disabling or enabling of logging. This can be useful if a model includes the mixin indirectly through another mixin or inheritance.
+
+```ruby
+class Parent
+  include Mongoid::Document
+  include Mongoid::AuditLog
+end
+
+class Child < Parent
+  disable_audit_log
+end
+
+class Grandchild < Child
+  enable_audit_log
+end
+
+Parent.audit_log_enabled? # => true
+Child.audit_log_enabled? # => false
+Grandchild.audit_log_enabled? # => true
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/mongoid/audit_log.rb
+++ b/lib/mongoid/audit_log.rb
@@ -14,12 +14,26 @@ module Mongoid
 
       AuditLog.actions.each do |action|
         send("before_#{action}") do
-          set_audit_log_changes if AuditLog.recording?
+          set_audit_log_changes if record_audit_log?
         end
 
         send("after_#{action}") do
-          save_audit_log_entry(action) if AuditLog.recording?
+          save_audit_log_entry(action) if record_audit_log?
         end
+      end
+    end
+
+    class_methods do
+      def enable_audit_log
+        @audit_log_enabled = true
+      end
+
+      def disable_audit_log
+        @audit_log_enabled = false
+      end
+
+      def audit_log_enabled?
+        !defined?(@audit_log_enabled) || @audit_log_enabled
       end
     end
 
@@ -60,6 +74,10 @@ module Mongoid
 
     def self.current_modifier=(modifier)
       Thread.current[:mongoid_audit_log_modifier] = modifier
+    end
+
+    def record_audit_log?
+      AuditLog.recording? && self.class.audit_log_enabled?
     end
 
     private


### PR DESCRIPTION
This change allows models that have the Mongoid::AuditLog
module included, either through another mixin or inheritance,
to disable logging for that specific model explicitly.